### PR TITLE
TASK-017-Exportar censo en diferentes formatos #22 #23

### DIFF
--- a/decide/census/tests.py
+++ b/decide/census/tests.py
@@ -1,6 +1,9 @@
-import random
+import json
+import tempfile
+import os
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 from rest_framework.test import APIClient
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 
@@ -13,8 +16,28 @@ from selenium.webdriver.common.keys import Keys
 from .models import Census
 from base import mods
 from base.tests import BaseTestCase
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
+class BaseExportTestCase(TestCase):
+    def setUp(self):
+        #Creamos 4 censos distintos
+        self.census_data = [
+            {
+                'voting_id': i,
+                'voter_id': i,
+            }
+            for i in range(1, 5) 
+        ]
+        #Creamos los censos con datos de census_data
+        self.census_create = [Census.objects.create(**data) for data in self.census_data]
+        
+        #Verificamos que cada censo creado, verifica que voter_id y voting_id son i+1
+        for i, censo in enumerate(self.census_create):
+            self.assertEqual(censo.voting_id, i + 1)
+            self.assertEqual(censo.voter_id, i + 1)
+        
+    def tearDown(self):
+        Census.objects.all().delete()
 
 class CensusTestCase(BaseTestCase):
 
@@ -164,3 +187,50 @@ class CensusTest(StaticLiveServerTestCase):
 
         self.assertTrue(self.cleaner.find_element_by_xpath('/html/body/div/div[3]/div/div[1]/div/form/div/p').text == 'Please correct the errors below.')
         self.assertTrue(self.cleaner.current_url == self.live_server_url+"/admin/census/census/add")
+
+class ExportCensusJSONTest(BaseExportTestCase):
+    def testExportListJson(self):
+        url_exportacion = reverse('export_census_json')
+        response = self.client.get(url_exportacion)
+        self.assertEqual(response.status_code, 200)
+
+        datos_exportados = json.loads(response.content.decode('utf-8'))
+
+        self.assertIsInstance(datos_exportados, list)
+        self.assertEqual(len(datos_exportados), len(self.census_create))
+
+        # Iteramos a través de cada elemento exportado y comparamos con la instancia de censo correspondiente
+        for indice, datos_censo_exportado in enumerate(datos_exportados):
+            if indice < len(self.census_create):
+                self.assertCheckCreatedCensusDataEqualsCensusData(datos_censo_exportado, self.census_create[indice])
+
+    def testExportedJsonFile(self):
+        url_exportacion = reverse('export_census_json')
+        response = self.client.get(url_exportacion)
+        self.assertEqual(response.status_code, 200)
+
+        datos_respuesta = json.loads(response.content.decode('utf-8'))
+
+        # Creamos un archivo temporal con extensión .json para almacenar los datos exportados
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False, mode='w+b') as archivo_temporal:
+            archivo_temporal.write(json.dumps(datos_respuesta, indent=2, default=str).encode('utf-8'))
+            ruta_archivo_temporal = archivo_temporal.name
+
+        self.assertTrue(os.path.exists(ruta_archivo_temporal))
+
+        # Leemos los datos guardados desde el archivo JSON temporal
+        with open(ruta_archivo_temporal, 'r', encoding='utf-8') as archivo_json_temporal:
+            datos_guardados = json.load(archivo_json_temporal)
+
+        # Comparamos cada conjunto de datos guardados con las instancias del censo creado
+        for indice, datos_censo_guardado in enumerate(datos_guardados):
+            if indice < len(self.census_create):
+                self.assertCheckCreatedCensusDataEqualsCensusData(datos_censo_guardado, self.census_create[indice])
+
+        os.remove(ruta_archivo_temporal)
+
+    def assertCheckCreatedCensusDataEqualsCensusData(self, exported_data, census_create):
+        self.assertEqual(exported_data['voting_id'], census_create.voting_id)
+        self.assertEqual(exported_data['voter_id'], census_create.voter_id)
+        expected_keys = ['voting_id', 'voter_id']
+        self.assertCountEqual(exported_data.keys(), expected_keys)

--- a/decide/census/tests.py
+++ b/decide/census/tests.py
@@ -264,11 +264,29 @@ class ExportCensusCSVTest(BaseExportTestCase):
         try:
             self.assertEqual(response_segunda.status_code, 200)
 
+            with open(archivo_temporal.name, 'r') as archivo:
+                contenido_archivo_temporal = list(csv.reader(archivo))
+
+            # Comparamos cada conjunto de datos exportados con las instancias del censo
+            for indice, datos_censo in enumerate(self.census_data):
+                if indice + 1 < len(lineas_respuesta_csv):
+                    self.assertCheckCreateCensusDataEqualCensusData(lineas_respuesta_csv[indice + 1], datos_censo)
+
+                if indice + 1 < len(contenido_archivo_temporal):
+                    self.assertCheckCreateCensusDataEqualCensusData(contenido_archivo_temporal[indice + 1], datos_censo)
 
         finally:
             os.remove(archivo_temporal.name)
 
-    
+    def assertCheckCreateCensusDataEqualCensusData(self, actual_data, census_create):
+        expected_data = [
+            str(census_create['voting_id']),
+            str(census_create['voter_id']),
+        ]
+
+        # Comparar los valores en las posiciones 0 y 1
+        self.assertEqual(expected_data[0], actual_data[0].strip())  # Comparar voting_id
+        self.assertEqual(expected_data[1], actual_data[1].strip())  # Comparar voter_id
 
 
         

--- a/decide/census/urls.py
+++ b/decide/census/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path, include
 from . import views
+from .views import *
 
 
 urlpatterns = [
     path('', views.CensusCreate.as_view(), name='census_create'),
     path('<int:voting_id>/', views.CensusDetail.as_view(), name='census_detail'),
+    path('export_csv/', ExportCensusCsv.as_view(), name='export_census_csv')
 ]

--- a/decide/census/urls.py
+++ b/decide/census/urls.py
@@ -6,5 +6,6 @@ from .views import *
 urlpatterns = [
     path('', views.CensusCreate.as_view(), name='census_create'),
     path('<int:voting_id>/', views.CensusDetail.as_view(), name='census_detail'),
-    path('export_csv/', ExportCensusCsv.as_view(), name='export_census_csv')
+    path('export_csv/', ExportCensusCsv.as_view(), name='export_census_csv'),
+    path('export_json/', ExportCensusJson.as_view(), name='export_census_json')
 ]

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -1,5 +1,6 @@
 from django.db.utils import IntegrityError
 from django.core.exceptions import ObjectDoesNotExist
+from django.views import View
 from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.status import (
@@ -12,6 +13,10 @@ from rest_framework.status import (
 
 from base.perms import UserIsStaff
 from .models import Census
+from django.http import HttpResponse
+import csv
+
+
 
 
 class CensusCreate(generics.ListCreateAPIView):
@@ -49,3 +54,20 @@ class CensusDetail(generics.RetrieveDestroyAPIView):
         except ObjectDoesNotExist:
             return Response('Invalid voter', status=ST_401)
         return Response('Valid voter')
+    
+class ExportCensusCsv(View):
+    def get (self, request):
+        census_data = Census.objects.all()
+        response = self.export_csv(census_data)
+        return response
+    
+    def export_csv(self, census_data):
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition']= 'attachment; filename="census.csv"'
+        writer = csv.writer(response)
+        writer.writerow(['voting_id', 'voter_id'])
+
+        for data in census_data:
+            writer.writerow([data.voting_id, data.voter_id])
+        
+        return response

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -67,7 +67,7 @@ class ExportCensusCsv(View):
             return HttpResponse('No data to export excel')
         
         counter = self.request.session.get('download_counter_csv', 1)
-        filename = f"census{counter}.csv"
+        filename = f"censusv{counter}.csv"
         self.request.session['download_counter_csv'] = counter + 1
 
         response = HttpResponse(content_type='text/csv')
@@ -96,7 +96,7 @@ class ExportCensusJson(View):
 
         data_json = json.dumps(data)
         counter = self.request.session.get('download_counter', 1)
-        filename = f"census{counter}.json"
+        filename = f"censusv{counter}.json"
         self.request.session['download_counter'] = counter + 1
 
         response = HttpResponse(data_json, content_type='text/json')


### PR DESCRIPTION
Se han realizado los tests para la integración de la posibilidad de exportar el censo en diferentes formatos, en este caso, como .csv y .json.
En total han sido 2 tests.